### PR TITLE
Make Dockerfile buildable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get update && \
         libgomp1 libxml2 libxml2-dev zlib1g-dev \
         libsnappy1v5 libsnappy-dev libonig2 make gcc g++ curl openjdk-8-jre && \
     curl https://bootstrap.pypa.io/get-pip.py | python3 && \
-    pip3 install --no-cache-dir PyStemmer bblfsh py4j modelforge parquet jinja2 libMHCUDA datasketch cassandra_driver python-igraph && \
+    pip3 install --no-cache-dir PyStemmer bblfsh py4j==0.10.4 modelforge parquet jinja2 libMHCUDA datasketch cassandra_driver python-igraph numpy humanize pygments && \
     apt-get remove -y python3-dev libxml2-dev libsnappy-dev zlib1g-dev make gcc g++ curl && \
     apt-get remove -y *-doc *-man >/dev/null && \
     apt-get autoremove -y && \
@@ -26,8 +26,9 @@ RUN apt-get update && \
 
 # sudo mount -o bind ... bundle/*
 ADD bundle/spark /spark/
-ADD bundle/engine/python/sourced/engine/ /packages/sourced/engine/
-ADD bundle/ml/sourced/ml/ /packages/sourced/ml/
+ADD bundle/engine/python /bundle/sourced/engine/
+ADD bundle/ml /bundle/sourced/ml/
+
 ADD apollo/ /packages/apollo/apollo/
 ADD setup.py /packages/apollo
 
@@ -35,6 +36,8 @@ ENV PYTHONPATH /packages:/spark/python
 ENV LANG en_US.UTF-8
 WORKDIR /packages
 
-RUN touch sourced/__init__.py && pip3 install --no-deps -e apollo/ && apollo warmup -s 'local[*]'
+RUN echo '0.5.2' > /bundle/sourced/engine/version.txt && pip3 install -e /bundle/sourced/engine/
+RUN pip3 install -e /bundle/sourced/ml/
+RUN pip3 install --no-deps -e apollo/ && apollo warmup -s 'local[*]'
 
 ENTRYPOINT ["apollo"]


### PR DESCRIPTION
Currently `docker build` fails with error:

```
pkg_resources.DistributionNotFound: The 'sourced-ml<0.5,>=0.4.4' distribution was not found and is required by apollo
```

Also docker image is missing sourced-ml dependencies.

This PR runs `pip3 install` for engine & sourced-ml to make apollo happy. It uses `--no-deps` flag to allow using tip of each package. (yep, for engine it sets 0.5.2 always to satisfy dependencies constraints, but the code can be newer)

Please let me know if I did something wrong.