### PR TITLE
Feature/bags saver

### DIFF
--- a/apollo/__main__.py
+++ b/apollo/__main__.py
@@ -2,11 +2,13 @@ import argparse
 import json
 import logging
 import sys
+import pip
 from time import time
 
 from igraph import Graph
 from modelforge.logs import setup_logging
 from sourced.ml import extractors
+from sourced.ml.__main__ import ArgumentDefaultsHelpFormatterNoNone
 from sourced.ml.utils import add_engine_args, add_spark_args
 from sourced.ml.cmd_entries.args import add_repo2_args, add_feature_args
 from sourced.ml.cmd_entries.repos2bow import add_bow_args
@@ -20,17 +22,17 @@ from apollo.query import query
 from apollo.warmup import warmup
 
 
-ENGINE_VERSION = "0.5.1"
+ENGINE_VERSION = {pkg.key: pkg.version for pkg in
+                  pip.get_installed_distributions()}["sourced-engine"]
+
 CASSANDRA_PACKAGE = "com.datastax.spark:spark-cassandra-connector_2.11:2.0.3"
 
 
 def get_parser() -> argparse.ArgumentParser:
     """
-    Create main parser.
-
-    :return: Parser
+    Create the cmdline argument parser.
     """
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(formatter_class=ArgumentDefaultsHelpFormatterNoNone)
     parser.add_argument("--log-level", default="INFO", choices=logging._nameToLevel,
                         help="Logging verbosity.")
 
@@ -69,24 +71,39 @@ def get_parser() -> argparse.ArgumentParser:
                                help="Number of hashes to query at a time.")
         my_parser.add_argument("--template", default=default_template,
                                help="Jinja2 template to render.")
-        add_cassandra_args(my_parser)
 
     def add_dzhigurda_arg(my_parser):
         my_parser.add_argument(
             "--dzhigurda", default=0, type=int,
             help="Index of the examined commit in the history.")
 
+    # Create and construct subparsers
     subparsers = parser.add_subparsers(help="Commands", dest="command")
 
+    # ------------------------------------------------------------------------
+    warmup_parser = subparsers.add_parser(
+        "warmup", help="Initialize source{d} engine.")
+    warmup_parser.set_defaults(handler=warmup)
+    add_engine_args(warmup_parser, default_packages=[CASSANDRA_PACKAGE])
+
+    # ------------------------------------------------------------------------
+    db_parser = subparsers.add_parser("resetdb", help="Destructively initialize the database.")
+    db_parser.set_defaults(handler=reset_db)
+    add_cassandra_args(db_parser)
+    db_parser.add_argument(
+        "--hashes-only", action="store_true",
+        help="Only clear the tables: hashes, hashtables, hashtables2. Do not touch the rest.")
+
+    # ------------------------------------------------------------------------
     preprocessing_parser = subparsers.add_parser(
         "preprocess", help="Generate the dataset with good candidates for duplication.")
     preprocessing_parser.set_defaults(handler=preprocess_source)
     preprocessing_parser.add_argument(
         "-r", "--repositories", required=True,
-        help="The path to the siva files with repositories.")
+        help="Path to the siva files with repositories.")
     preprocessing_parser.add_argument(
         "-o", "--output", required=True,
-        help="[OUT] The path to the Parquet files with bag batches.")
+        help="[OUT] Path to the Parquet files with bag batches.")
     add_dzhigurda_arg(preprocessing_parser)
     preprocessing_parser.add_argument(
         "-l", "--languages", action="append",
@@ -100,6 +117,7 @@ def get_parser() -> argparse.ArgumentParser:
         help="Fields to select from DF to save.")
     add_engine_args(preprocessing_parser)
 
+    # ------------------------------------------------------------------------
     source2bags_parser = subparsers.add_parser(
         "bags", help="Convert source code to weighted sets.")
     source2bags_parser.set_defaults(handler=source2bags)
@@ -110,15 +128,11 @@ def get_parser() -> argparse.ArgumentParser:
     add_cassandra_args(source2bags_parser)
     add_engine_args(source2bags_parser, default_packages=[CASSANDRA_PACKAGE])
 
-    warmup_parser = subparsers.add_parser(
-        "warmup", help="Initialize source{d} engine.")
-    warmup_parser.set_defaults(handler=warmup)
-    add_engine_args(warmup_parser, default_packages=[CASSANDRA_PACKAGE])
-
+    # ------------------------------------------------------------------------
     hash_parser = subparsers.add_parser(
         "hash", help="Run MinHashCUDA on the bag batches.")
     hash_parser.set_defaults(handler=hash_batches)
-    hash_parser.add_argument("input",
+    hash_parser.add_argument("-i", "--input",
                              help="Path to the directory with Parquet files.")
     hash_parser.add_argument("--seed", type=int, default=int(time()),
                              help="Random generator's seed.")
@@ -133,6 +147,7 @@ def get_parser() -> argparse.ArgumentParser:
     add_spark_args(hash_parser, default_packages=[CASSANDRA_PACKAGE])
     add_feature_weight_arg(hash_parser)
 
+    # ------------------------------------------------------------------------
     query_parser = subparsers.add_parser("query", help="Query for similar files.")
     query_parser.set_defaults(handler=query)
     mode_group = query_parser.add_mutually_exclusive_group(required=True)
@@ -140,39 +155,36 @@ def get_parser() -> argparse.ArgumentParser:
     mode_group.add_argument("-c", "--file", help="Query for this file (file mode).")
     query_parser.add_argument("--docfreq", help="Path to OrderedDocumentFrequencies (file mode).")
     query_parser.add_argument(
-        "--bblfsh", default="localhost:9432", help="Babelfish server's endpoint.")
-    add_feature_args(query_parser, required=False)
+        "--bblfsh", default="localhost:9432", help="Babelfish server's address.")
     query_parser.add_argument("--precise", action="store_true",
                               help="Calculate the precise set.")
     add_wmh_args(query_parser, "Path to the Weighted MinHash parameters.", False, False)
+    add_feature_args(query_parser, required=False)
     add_template_args(query_parser, "query.md.jinja2")
+    add_cassandra_args(query_parser)
 
-    db_parser = subparsers.add_parser("resetdb", help="Destructively initialize the database.")
-    db_parser.set_defaults(handler=reset_db)
-    add_cassandra_args(db_parser)
-    db_parser.add_argument(
-        "--hashes-only", action="store_true",
-        help="Only clear the tables: hashes, hashtables, hashtables2. Do not touch the rest.")
-
+    # ------------------------------------------------------------------------
     cc_parser = subparsers.add_parser(
         "cc", help="Load the similar pairs of files and run connected components analysis.")
     cc_parser.set_defaults(handler=find_connected_components)
     add_cassandra_args(cc_parser)
-    cc_parser.add_argument("-o", "--output",
-                           help="Path to save the asdf file with connected components.")
+    cc_parser.add_argument("-o", "--output", required=True,
+                           help="[OUT] Path to connected components ASDF model.")
 
+    # ------------------------------------------------------------------------
     dumpcc_parser = subparsers.add_parser(
         "dumpcc", help="Output the connected components to stdout.")
     dumpcc_parser.set_defaults(handler=dumpcc)
-    dumpcc_parser.add_argument("input", help="Path to the asdf file with CCs.")
-
+    dumpcc_parser.add_argument("-i", "--input", required=True,
+                               help="Path to connected components ASDF model.")
+    # ------------------------------------------------------------------------
     community_parser = subparsers.add_parser(
         "cmd", help="Run Community Detection analysis on the connected components from \"cc\".")
     community_parser.set_defaults(handler=detect_communities)
     community_parser.add_argument("-i", "--input", required=True,
-                                  help="The path to connected components ASDF model.")
+                                  help="Path to connected components ASDF model.")
     community_parser.add_argument("-o", "--output", required=True,
-                                  help="Output path to the communities ASDF model.")
+                                  help="[OUT] Path to the communities ASDF model.")
     community_parser.add_argument("--edges", choices=("linear", "quadratic", "1", "2"),
                                   default="linear",
                                   help="The method to generate the graph's edges: bipartite - "
@@ -188,12 +200,15 @@ def get_parser() -> argparse.ArgumentParser:
     community_parser.add_argument("--no-spark", action="store_true", help="Do not use Spark.")
     add_spark_args(community_parser)
 
+    # ------------------------------------------------------------------------
     dumpcmd_parser = subparsers.add_parser(
         "dumpcmd", help="Output the detected communities to stdout.")
     dumpcmd_parser.set_defaults(handler=dumpcmd)
-    dumpcmd_parser.add_argument("input", help="Path to the asdf file with communities.")
+    dumpcmd_parser.add_argument("input", help="Path to the communities ASDF model.")
     add_template_args(dumpcmd_parser, "report.md.jinja2")
+    add_cassandra_args(dumpcmd_parser)
 
+    # ------------------------------------------------------------------------
     evalcc_parser = subparsers.add_parser(
         "evalcc", help="Evaluate the communities: calculate the precise similarity and the "
                        "fitness metric.")
@@ -206,14 +221,12 @@ def get_parser() -> argparse.ArgumentParser:
     add_spark_args(evalcc_parser, default_packages=[CASSANDRA_PACKAGE])
     add_cassandra_args(evalcc_parser)
 
-    # TODO: retable [.....] -> [.] [.] [.] [.] [.]
-
     return parser
 
 
 def main():
     """
-    Creates all the argparse-rs and invokes the function from set_defaults().
+    Creates all the argument parsers and invokes the function from set_defaults().
 
     :return: The result of the function from set_defaults().
     """

--- a/apollo/bags.py
+++ b/apollo/bags.py
@@ -2,11 +2,14 @@ import logging
 import os
 from uuid import uuid4
 
-from sourced.ml.cmd_entries.repos2bow import repos2bow_entry_template
-from sourced.ml.utils import create_engine
+from sourced.ml.extractors import create_extractors_from_args
+from sourced.ml.models import OrderedDocumentFrequencies, QuantizationLevels
 from sourced.ml.transformers import UastExtractor, Transformer, Ignition, \
-    FieldsSelector, ParquetSaver
-from sourced.ml.utils.engine import pause, pipeline_graph
+    FieldsSelector, ParquetSaver, create_parquet_loader, Moder, Cacher, UastRow2Document, \
+    Uast2BagFeatures, Indexer, Uast2Quant, UastDeserializer, TFIDF, BagFeatures2DocFreq, \
+    BagFeatures2TermFreq, BOWWriter
+from sourced.ml.utils.engine import pause, pipeline_graph, create_engine
+
 from pyspark.sql.types import Row
 
 from apollo import cassandra_utils
@@ -19,9 +22,8 @@ class BagsSaver(Transformer):
         self.table = table
 
     def __call__(self, head):
-        rows = head.map(lambda row: Row(sha1=row.document,
-                                        item=row.token,
-                                        value=float(row.value)))
+        rows = head.map(lambda row: Row(
+            sha1=row.document, item=row.token, value=float(row.value)))
         if self.explained:
             self._log.info("toDebugString():\n%s", rows.toDebugString().decode())
         rows.toDF() \
@@ -86,9 +88,60 @@ def preprocess_source(args):
     pipeline_graph(args, log, ignition)
 
 
+@pause
 def source2bags(args):
+    log = logging.getLogger("sourced2bags")
+    extractors = create_extractors_from_args(args)
+    session_name = "sourced2bags-%s" % uuid4()
     cassandra_utils.configure(args)
-    return repos2bow_entry_template(
-        args,
-        select=lambda: DzhigurdaFiles(args.dzhigurda),
-        cache_hook=lambda: MetadataSaver(args.keyspace, args.tables["meta"]))
+    if args.parquet:
+        start_point = create_parquet_loader(session_name, **args.__dict__)
+        root = start_point
+    else:
+        engine = create_engine(session_name, **args.__dict__)
+        root = engine
+        start_point = Ignition(engine, explain=args.explain) \
+            .link(DzhigurdaFiles(dzhigurda=args.dzhigurda)) \
+            .link(UastExtractor(languages=args.languages))
+
+    uast_extractor = start_point.link(Moder(args.mode)) \
+        .link(Cacher.maybe(args.persist))
+    log.info("Writing metadata to DB... ")
+    uast_extractor.link(MetadataSaver(keyspace=args.keyspace, table=args.tables["meta"])) \
+        .execute()
+
+    uast_extractor = uast_extractor.link(UastRow2Document())
+    log.info("Extracting UASTs and indexing documents...")
+    document_indexer = Indexer(Uast2BagFeatures.Columns.document)
+    uast_extractor.link(document_indexer).execute()
+    ndocs = len(document_indexer)
+    log.info("Number of documents: %d", ndocs)
+    uast_extractor = uast_extractor.link(UastDeserializer())
+    quant = Uast2Quant(extractors)
+    uast_extractor.link(quant).execute()
+    if quant.levels:
+        log.info("Writing quantization levels to %s", args.quant)
+        QuantizationLevels().construct(quant.levels).save(args.quant)
+    uast_extractor = uast_extractor \
+        .link(Uast2BagFeatures(extractors)) \
+        .link(Cacher.maybe(args.persist))
+    log.info("Calculating the document frequencies...")
+    df = uast_extractor.link(BagFeatures2DocFreq()).execute()
+    log.info("Writing docfreq to %s", args.docfreq)
+    df_model = OrderedDocumentFrequencies() \
+        .construct(ndocs, df) \
+        .prune(args.min_docfreq) \
+        .greatest(args.vocabulary_size) \
+        .save(args.docfreq)
+    bags = uast_extractor \
+        .link(BagFeatures2TermFreq()) \
+        .link(TFIDF(df_model)) \
+        .link(document_indexer) \
+        .link(Indexer(Uast2BagFeatures.Columns.token, df_model.order)) \
+        .link(Cacher.maybe(args.persist))
+    bags.link(BOWWriter(document_indexer, df_model, args.bow, args.batch))\
+        .execute()
+    log.info("Writing bags to DB... ")
+    bags.link(BagsSaver(keyspace=args.keyspace, table=args.tables["bags"])) \
+        .execute()
+    pipeline_graph(args, log, root)

--- a/apollo/graph.py
+++ b/apollo/graph.py
@@ -279,7 +279,8 @@ class CommunityDetector:
             kwargs = {"weights": graph.edge_weights}
         if self.algorithm == "edge_betweenness":
             kwargs["directed"] = False
-        result = action(**kwargs, **self.config)
+        kwargs.update(self.config)
+        result = action(**kwargs)
 
         if hasattr(result, "as_clustering"):
             result = result.as_clustering()

--- a/apollo/graph.py
+++ b/apollo/graph.py
@@ -327,7 +327,7 @@ class BatchedCommunityResolver:
         for i, community in enumerate(model.communities):
             for j in community:
                 try:
-                    yield id_to_element[j], i
+                    yield id_to_element[j].split("@")[1], i
                 except IndexError:
                     continue
 
@@ -354,7 +354,7 @@ class CommunityEvaluator:
         if len(elements) == 1:
             return (0,) * 4
         for key, vals in elements.items():
-            vec  = numpy.zeros(self.vocabulary_size, dtype=numpy.float32)
+            vec = numpy.zeros(self.vocabulary_size, dtype=numpy.float32)
             for i, w in vals:
                 vec[i] = w
             elements[key] = vec

--- a/apollo/query.py
+++ b/apollo/query.py
@@ -101,4 +101,4 @@ def stream_template(name, dest, **kwargs):
     )
     template = loader.load(env, name)
     log.info("Rendering")
-    template.stream(**kwargs, format_url=format_url).dump(dest)
+    template.stream(format_url=format_url, **kwargs).dump(dest)


### PR DESCRIPTION
- Solved [issue 33](https://github.com/src-d/apollo/issues/33) by moving back logic
- Refactored the get_parser a bit: moved the subparsers to match expected order of utilization and seperated them nicely, made `engine` version dynamic  like in `ml`, took out `add_cassandra_args` from `add_templates_args` (confusing when debugging and did not bring much)
- Solved two non reported bug I was having (both `SyntaxError`):
    - In `stream_template` function of `query.py` file, simply switched both arguments
    - In `__call__` method of `CommunityDetector`  in `graph.py` file, added config to `kwarg` dict with `update` methode and removed it from the call to one of the native methods to detect communities of igraph's `Graph` class

EDIT: `dumpcmd` was not working anymore, the query done on the meta table was returning nothing so the communities part of the template was empty. Found that it was bc the `WHERE`clause was querying on the sha1 column, but the values we inputted in the first place were of the form 'reponame@sha1'. Solved it by splitting the strings in the approriate generator 

Error logs, respectively for `query.py`:
```
Traceback (most recent call last):
  File "/usr/local/bin/apollo", line 11, in <module>
    load_entry_point('apollo==0.1.0', 'console_scripts', 'apollo')()
  File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 480, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 2693, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 2324, in load
    return self.resolve()
  File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 2330, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python3.4/dist-packages/apollo/__main__.py", line 16, in <module>
    from apollo.graph import find_connected_components, dumpcc, detect_communities, dumpcmd, \
  File "/usr/local/lib/python3.4/dist-packages/apollo/graph.py", line 18, in <module>
    from apollo.query import weighted_jaccard, stream_template
  File "/usr/local/lib/python3.4/dist-packages/apollo/query.py", line 105
    template.stream(**kwargs, format_url=format_url).dump(dest)
                            ^
SyntaxError: invalid syntax
```

And for `graph.py`:
```
Traceback (most recent call last):
  File "/usr/local/bin/apollo", line 11, in <module>
    load_entry_point('apollo==0.1.0', 'console_scripts', 'apollo')()
  File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 480, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 2693, in load_entry_point
    return ep.load()
  File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 2324, in load
    return self.resolve()
  File "/usr/local/lib/python3.4/dist-packages/pkg_resources/__init__.py", line 2330, in resolve
    module = __import__(self.module_name, fromlist=['__name__'], level=0)
  File "/usr/local/lib/python3.4/dist-packages/apollo/__main__.py", line 16, in <module>
    from apollo.graph import find_connected_components, dumpcc, detect_communities, dumpcmd, \
  File "/usr/local/lib/python3.4/dist-packages/apollo/graph.py", line 282
    result = action(**kwargs, self.config)
                            ^
SyntaxError: invalid syntax
```