### PR TITLE
Make port optional in cassandra_utils.get_db

### DIFF
--- a/apollo/cassandra_utils.py
+++ b/apollo/cassandra_utils.py
@@ -36,10 +36,14 @@ def configure(args):
 def get_db(args):
     log = logging.getLogger("cassandra")
     patch_tables(args)
-    cashost, casport = args.cassandra.split(":")
+    try:
+        cas_host, cas_port = args.cassandra.split(":")
+    except ValueError:
+        cas_host = args.cassandra
+        cas_port = "9042"
 
     def get_cluster():
-        return Cluster((cashost,), port=int(casport),
+        return Cluster((cas_host,), port=int(cas_port),
                        load_balancing_policy=RoundRobinPolicy())
     cluster = get_cluster()
     log.info("Connecting to %s", args.cassandra)


### PR DESCRIPTION
The `docker run` commands from the readme fail because the port is not optional.
This PR fixes what I think was a bug introduced in https://github.com/src-d/apollo/commit/dd3bd7fe915aa8b87114a9ec7ff90c09df15eb56, when the port was made optional in `configure` but not in `get_db`.