### PR TITLE
Fix dumpcmd

### DIFF
--- a/apollo/graph.py
+++ b/apollo/graph.py
@@ -326,7 +326,7 @@ class BatchedCommunityResolver:
         for i, community in enumerate(model.communities):
             for j in community:
                 try:
-                    yield id_to_element[j], i
+                    yield id_to_element[j].split("@")[1], i
                 except IndexError:
                     continue
 
@@ -353,7 +353,7 @@ class CommunityEvaluator:
         if len(elements) == 1:
             return (0,) * 4
         for key, vals in elements.items():
-            vec  = numpy.zeros(self.vocabulary_size, dtype=numpy.float32)
+            vec = numpy.zeros(self.vocabulary_size, dtype=numpy.float32)
             for i, w in vals:
                 vec[i] = w
             elements[key] = vec


### PR DESCRIPTION
The `_gen_hashes` method yielded tuples of the form: (repo@sha1hash, id) instead of: (sha1hash, id) which f*cked up the query done to the metadata table, and had for effect of reporting on none of the communities in the report.