### PR TITLE
Syntax bugs with **kwargs

### DIFF
--- a/apollo/graph.py
+++ b/apollo/graph.py
@@ -279,8 +279,9 @@ class CommunityDetector:
             kwargs = {"weights": graph.edge_weights}
         if self.algorithm == "edge_betweenness":
             kwargs["directed"] = False
-        result = action(**kwargs, **self.config)
-
+        # TODO: Rollback to action(**kwargs, **self.config) when support for Python3.4 is over
+        kwargs.update(self.config)
+        result = action(**kwargs)
         if hasattr(result, "as_clustering"):
             result = result.as_clustering()
 

--- a/apollo/query.py
+++ b/apollo/query.py
@@ -101,4 +101,4 @@ def stream_template(name, dest, **kwargs):
     )
     template = loader.load(env, name)
     log.info("Rendering")
-    template.stream(**kwargs, format_url=format_url).dump(dest)
+    template.stream(format_url=format_url, **kwargs).dump(dest)


### PR DESCRIPTION
The first bug in `query.py` is simply syntax, the second is due to Python3.4 (added a TODO to rollback to old syntax when we stop supporting it).