### PR TITLE
Saving bags with second hook

### DIFF
--- a/apollo/bags.py
+++ b/apollo/bags.py
@@ -30,6 +30,7 @@ class BagsSaver(Transformer):
             .mode("append") \
             .options(table=self.table, keyspace=self.keyspace) \
             .save()
+        return head
 
 
 class MetadataSaver(Transformer):
@@ -91,4 +92,5 @@ def source2bags(args):
     return repos2bow_entry_template(
         args,
         select=lambda: DzhigurdaFiles(args.dzhigurda),
-        cache_hook=lambda: MetadataSaver(args.keyspace, args.tables["meta"]))
+        cache_hook=lambda: MetadataSaver(args.keyspace, args.tables["meta"]),
+        save_hook=lambda: BagsSaver(args.keyspace, args.tables["bags"]))


### PR DESCRIPTION
Should not be merged unless this is: https://github.com/src-d/ml/pull/216
Uses second the second hook added in that ml PR to save the bags table, while using the template.

EDIT: now returning the head after files has been saved in `BagsSaver`, so we don't get error when piping to `BOWWriter`