### PR TITLE
Fix query subcommand

### DIFF
--- a/apollo/__main__.py
+++ b/apollo/__main__.py
@@ -140,6 +140,9 @@ def get_parser() -> argparse.ArgumentParser:
     mode_group.add_argument("-c", "--file", help="Query for this file (file mode).")
     query_parser.add_argument("--docfreq", help="Path to OrderedDocumentFrequencies (file mode).")
     query_parser.add_argument(
+        "--min-docfreq", default=1, type=int,
+        help="The minimum document frequency of each feature.")
+    query_parser.add_argument(
         "--bblfsh", default="localhost:9432", help="Babelfish server's endpoint.")
     add_feature_args(query_parser, required=False)
     query_parser.add_argument("--precise", action="store_true",

--- a/apollo/hasher.py
+++ b/apollo/hasher.py
@@ -217,7 +217,11 @@ def hash_file(args):
         ex.ndocs = vocab.docs
         ex.docfreq = vocab
         for k, v in ex.extract(uast):
-            bag[vocab.order[k]] = v
+            try:
+                bag[vocab.order[k]] = v
+            except KeyError:
+                continue
+
     log.info("Bag size: %d", len(bag.nonzero()[0]))
     log.info("Hashing")
     return weighted_minhash(bag, params.rs.shape[0], params.rs, params.ln_cs, params.betas), bag


### PR DESCRIPTION
1. Add `--min-docfreq` param. Query calls [hash_file](https://github.com/src-d/apollo/blob/master/apollo/query.py#L30) and it [expects](https://github.com/src-d/apollo/blob/master/apollo/hasher.py#L213) this parameter.

2. A feature of a file is not necessarily presented in vocabulary.