### PR TITLE
Add documentation to all commands

### DIFF
--- a/doc/cmd/bags.md
+++ b/doc/cmd/bags.md
@@ -1,0 +1,55 @@
+# Bags command
+
+This command converts input repositories to unordered weighted bags of features that are stored in DB, writes MinHashCuda batches, and writes the Ordered Documents Frequency model as well as the optional Quantization Levels model. You can specify the following arguments:
+
+- `-r`/`--repositories` : Path to the input files
+- `--parquet`: If your input files are Parquet files
+- `--graph`: Path to the output Graphviz file, if you wish to keep the tree
+- `-l`/`--languages` : Languages to keep, defaults to all languages detected by Babelfish
+- `--dzhigurda`: Index of the last commit to keep, defaults to 0 (only the head), 1 is HEAD~2, etc
+- `--bow`: Path to the output batches
+- `--batch`: The maximum size of a single batch in bytes
+- `--min-docfreq`: Specific minimum document frequency of each feature, defaults to 1
+- `--docfreq`: Path to the output Ordered Document Frequency model
+- `-v`/`--vocabulary-size`: to specify the maximum vocabulary size, defaults to 10 million
+- [Spark and Engine arguments](https://github.com/src-d/ml/blob/master/doc/spark.md)
+- [Cassandra/Scylla arguments](db.md)
+
+You must also specify arguments for the **features**:
+
+- `-x`/`--mode`: Mode to select for analysis, defaults to `file`, can also be `repo` or `func`
+- `--quant`: Path to the output Quantization Levels model (optional)
+- `-f`/`--feature`: Features to extract from each item, at the moment among the ones below
+
+
+| Feature  | Description                        |
+|----------|:---------------------------------:|
+| graphlet | Converts the UAST to a weighted bag of graphlets, a graphlet of a UAST node is composed from the node itself, its parent and its children|
+| lit      | Converts the UAST to a weighted bag of literals (UAST node role)
+| id       | Converts the UAST to a weighted bag of identifiers (UAST node role)
+| children | Converts the UAST to a bag of (internal type, quantized number of children) pairs, see [quantization](https://en.wikipedia.org/wiki/Quantization_(signal_processing)) for more info |  
+| uast2seq | Converts the UAST to a bag of sequences of nodes, we use Depth First Search for the traversal of the UAST | 
+| node2vec | Converts the UAST to a bag of vectorized sequences produced through a random walk
+
+You can check out the [Babelfish documentation](https://doc.bblf.sh/) for more information about UASTs. The weights of each feature in a bag are always computed from the observed frequencies. 
+
+- `--<feature>-<arg>`: For each of the above features you can also specify arguments:
+
+| Feature  | Flag                              | Default | Description |
+|----------|:---------------------------------:|:-------:|:------------:|
+| graphlet | --graphlet-weight                 | 1       | Weight of this feature relative to the others (used by TF-IDF) |
+| lit      | --lit-weight                      | 1       | Weight of this feature relative to the others (used by TF-IDF) |
+| id       | --id-split-stem                   | False   | Whether to split identifiers and consider each part to be a separate one, or not |
+| id       | --id-weight                       | 1       | Weight of this feature relative to the others (used by TF-IDF) |
+| children | --children-npartitions            | 10      | Number of partitions on which we apply quantization |
+| uast2seq | --uast2seq-weight                 | 1       | Weight of this feature relative to the others (used by TF-IDF) |
+| uast2seq | --uast2seq-seq-len                | 5       | Length(s) of sequences, can be a list |
+| uast2seq | --uast2seq-stride                 | 1       | Stride used to iterate through the sequenced UAST to extract subsequences of chosen length |
+| node2vec | --node2vec-weight                 | 1       | Weight of this feature relative to the others (used by TF-IDF)
+| node2vec | --node2vec-seq-len                | (5, 6)  | Length(s) of sequences to be vectorized, can be a list
+| node2vec | --node2vec-p-explore-neighborhood | 0.5     | Likelihood of immediately revisiting a node in the walk (*return parameter*)|
+| node2vec | --node2vec-stride                 | 1       | Strides used to iterate through the walk sequences to extract subsequences of chosen length |
+| node2vec | --node2vec-seed                   | 42      | Seed to use to generate the random walk |
+| node2vec | --node2vec-q-leave-neighborhood   | 0.5     | Modulates the ability to differentiate between inward and outward nodes (*in out parameter*) |
+| node2vec | --node2vec-n-walks                | 5       | Number of walks from each node. |
+| node2vec | --node2vec-n-steps                | 19      | Number of steps in each walk. |

--- a/doc/cmd/cc.md
+++ b/doc/cmd/cc.md
@@ -1,0 +1,6 @@
+# CC command
+
+This command runs the connected components analysis on previously created hash tables, you can specify the following arguments:
+
+- `o`/`--output`: Path to the output Connected Components model
+- [Cassandra/Scylla arguments](db.md)

--- a/doc/cmd/cmd.md
+++ b/doc/cmd/cmd.md
@@ -1,0 +1,26 @@
+# CMD command
+
+__Currently does not work in Spark Cluster mode.__
+
+This command runs the community detection on a Connected Components model, you can specify the following arguments:
+
+- `-i`/`--input`: Path to the input Connected Components model
+- `-o`/`--output`: Path to the output Community Detection model
+- `--edges`: Specific method to be used to generate edges, quadratic will connect each item in each bucket to all other items, while the  default, linear, will create for each bucket an artificial vertex to which all items will be connected. Depending on the method the edges will be created in quadratic or linear time, relatively to the number of buckets
+- `--no-spark`: If you do not want to use Spark - *but who would want that ?*
+- [Spark arguments](https://github.com/src-d/ml/blob/master/doc/spark.md) if you choose to use it
+- `-a`/`--algorithm`: Community detection algorithm to apply, defaults to `walktrap`, check out the [igraph](http://igraph.org/c/doc/igraph-Community.html) doc to learn more. See below for the full list of available algorithms and their parameters as of today (see code in `igraph/__init__.py` for description of parameters), we excluded parameters that modify the returned object
+- `-p`/`--params`: Depending on the algorithm, you may need to specify parameters (JSON format)
+
+| Algorithm  | Parameters |
+|:----------:|:----------:|
+|community_fastgreedy|weights (for edges)|
+|community_infomap|edge_weights, vertex_weights, trials|
+|community_leading_eigenvector_naive|clusters|
+|community_leading_eigenvector|clusters, weights (for edges), arpack_options|
+|community_label_propagation|weights (for edges), initial, fixed|
+|community_multilevel|weights (for edges)|
+|community_optimal_modularity|weights (for edges)|
+|community_edge_betweenness|weights (for edges), clusters, directed|
+|community_spinglass|weights (for edges), spins, parupdate, start_temp, stop_temp, cool_fact, update_rule, gamma, _lambda, implementation|
+|community_walktrap|weights (for edges), steps|

--- a/doc/cmd/db.md
+++ b/doc/cmd/db.md
@@ -1,0 +1,7 @@
+# Cassandra/Scylla arguments
+
+For all of the commands that require access to the database, you can specify the following arguments:
+
+- `--cassandra`: Specific address of your Scylla/Cassandra DB, if you are not running it locally (the format is `<address>:<port>`, if you are using the default 9042 port then no need to specify it, e.g. `--cassandra scylla`)
+- `--keyspace`: Specific name of the Cassandra key space, defaults to `apollo`
+- `--tables`: Specific table mapping, use JSON format to modify it, e.g. `--tables {"bags": "bags_2", "hashes": "hashes_2", "hashtables": "hashtables_2", "hashtables2": "hashtables2_2"}`

--- a/doc/cmd/dumpcc.md
+++ b/doc/cmd/dumpcc.md
@@ -1,0 +1,5 @@
+# DumpCC command
+
+This command outputs a report on the given Connected Components model to stdout, you must specify the following argument:
+
+- `-i`/`--input`: Path to the input Connected Components model

--- a/doc/cmd/dumpcmd.md
+++ b/doc/cmd/dumpcmd.md
@@ -1,0 +1,8 @@
+# DumpCMD command
+
+This command outputs a report on the given Community Detection model to stdout, you can specify the following arguments:
+
+- `--template`: Path to the `report.md.jinja2` file
+- `--batch`: Same as in `query` the number of hashes to query simultaneously, defaults to 100
+- `-i`/`--input`: Path to the input Community Detection model
+- [Cassandra/Scylla arguments](db.md)

--- a/doc/cmd/evalcc.md
+++ b/doc/cmd/evalcc.md
@@ -1,0 +1,11 @@
+# EvalCC command
+
+__Currently does not work in Spark Cluster mode.__
+
+This command calculates the precise similarity and fitness metrics for the given Community Detection model, you can specify the following arguments:
+
+- `-i`/`--input`: Path to the input Community Detection model;
+- `-t`/`--threshold`: Jacquard Similarity threshold (float in [0,1]) over which we consider there is similarity - to calculate number of misses
+- [Cassandra/Scylla arguments](db.md)
+- [Spark arguments](https://github.com/src-d/ml/blob/master/doc/spark.md)
+ 

--- a/doc/cmd/hash.md
+++ b/doc/cmd/hash.md
@@ -1,0 +1,21 @@
+# Hash command
+
+__Currently does not work in Spark Cluster mode.__
+
+This command applies the MinHashCUDA algorithm on previously written batches, stores hashes and hash tables in DB and saves the Weighted MinHash (WMH) parameters.
+
+- `-i`/`--input`: Path to the input batch(es)
+- `--seed`: Specific random generator (useful for cross execution comparisons), default to a random number depending of the time
+- `--mhc-verbosity`: MinHashCuda log level, specify 0 for silence or 2 for full logs, 1 is the default and just shows progress
+- `--devices`: Index of NVIDIA device to use, defaults to 0 (all available)
+- `--docfreq`: Path to the input Ordered Document Frequency model
+- `--size`: Hash size, defaults to 128
+- [Cassandra/Scylla arguments](db.md)
+- [Spark arguments](https://github.com/src-d/ml/blob/master/doc/spark.md)
+
+You must also specify WMH arguments:
+
+- `-p`/`--params`: Path to the output WMH parameters
+- `-t`/`--threshold`: Jacquard Similarity threshold (float in [0,1]) over which we consider there is similarity
+- `--false-positive-weight`: Parameter that adjusts the relative importance of minimizing false positives count when optimizing for the Jacquard similarity threshold, default to .5
+- `--false-negative-weight`: Same for false negatives

--- a/doc/cmd/preprocess.md
+++ b/doc/cmd/preprocess.md
@@ -1,0 +1,12 @@
+# Preprocess command
+
+This command allows you to preprocess your data before passing it to the [bags](bags.md) command. It converts the input files into Parquet files, after selecting commits, filtering by language, extracting UASTs and possibly taking out some of the fields. You can specify the following arguments:
+
+- `-r`/`--repositories` : Path to the input files
+- `--parquet`: If your input files are Parquet files
+- `--graph`: Path to the output Graphviz file if you wish to keep the tree
+- `-o`/`--output`: Path to the output Parquet files
+- `-f`/`--fields`: Fields to keep, defaults to all, i.e. "blob_id", "repository_id", "content", "path", "commit_hash" and "uast"
+- `-l`/`--languages` : Languages to keep, defaults to all languages detected by Babelfish
+- `--dzhigurda`: Index of the last commit to keep, defaults to 0 (only the head), 1 is HEAD~2, etc
+- [Spark and Engine arguments](https://github.com/src-d/ml/blob/master/doc/spark.md)

--- a/doc/cmd/query.md
+++ b/doc/cmd/query.md
@@ -1,0 +1,25 @@
+# Query command
+
+This command finds items similar to the one specified, and outputs them using the `query.md.jinja2` report file. There are two query modes, that are mutually exclusive. For both of them you can specify the following arguments:
+
+- `--precise`: Whether to calculate the precise set or not
+- `--template`: Path to `query.md.jinja2`
+- `--batch`: Number of hashes to query simultaneously, defaults to 100
+- [Cassandra/Scylla arguments](db.md)
+
+**Id mode:**
+
+In this mode, the file is already in the databases, it's features have been extracted. You only need to specify which file you wish to pick with:
+
+- `-i`/`--id`: SHA1 identifier of the file.
+
+**File mode:**
+
+In this mode, the file is not in the database, so additionally we have to extract the bag of features from that file and apply the MinHashCUDA algorithm on them. You must specify the following arguments:
+
+- `-c`/`--file`: Absolute path of the file
+- `--bblfsh`: Same as in [engine arguments]((https://github.com/src-d/ml/blob/master/doc/spark.md))
+- `--docfreq`: Path to the input Ordered Document Frequency model created while running the `bags`command (optional)
+- `--min-docfreq`: Specific minimum document frequency of each feature, defaults to 1
+- [Feature arguments](bags.md) also used by the `bags` command
+- [WMH arguments](hash.md) also used by the `hash` command

--- a/doc/cmd/resetdb.md
+++ b/doc/cmd/resetdb.md
@@ -1,0 +1,6 @@
+# Resetdb command
+
+This command destructively resets the database, you can specify the following arguments:
+
+- `--hashes-only`: To clear only the hash tables
+- [Cassandra/Scylla arguments](db.md)


### PR DESCRIPTION
Moved what was relevant from the private apollo guide, I used the already existing md files and also created a new db.md file for the Cassandra/Scylla arguments, since they are used by all commands.