### PR TITLE
Correct README.md and 101.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ in your browser. There multiple Docker options available, e.g.
 
 ```
 docker run -it --rm -v /path/to/io:/io --link bblfshd --link scylla srcd/apollo bags -r /io/siva \
---bow /io/bags/bow.asdf --docfreq /io/bags/docfreq.asdf -f id -f lit -f uast2seq --uast2seq-seq-len 4 \
--l Java -s 'local[*]' --min-docfreq 5 --bblfsh bblfshd --cassandra scylla --persist MEMORY_ONLY \
+--bow /io/bags/bow.asdf --docfreq /io/bags/docfreq.asdf -f id lit uast2seq --uast2seq-seq-len 4 \
+-l Java Python -s 'local[*]' --min-docfreq 5 --bblfsh bblfshd --cassandra scylla --persist MEMORY_ONLY \
 --config spark.executor.memory=4G --config spark.driver.memory=10G --config spark.driver.maxResultSize=4G
 ```
 

--- a/doc/101.md
+++ b/doc/101.md
@@ -23,8 +23,8 @@ are additionally saved in the database.
 
 ```
 apollo bags -r /data --bow bow.asdf --docfreq docfreq.asdf \
-    -f lit -f id -f uast2seq --uast2seq-seq-len 4 --uast2seq-weight 2 --min-docfreq 4 \
-    -l Java --persist DISK_ONLY
+    -f lit id uast2seq --uast2seq-seq-len 4 --uast2seq-weight 2 --min-docfreq 4 \
+    -l Java Python --persist DISK_ONLY
 ```
 
 > Docker users should add `--bblfsh bblfshd --cassandra cassandra`.


### PR DESCRIPTION
The example command for bags is incorrect:

---> with `-f id -f lit -f uast2seq` you only get `feature=['uast2seq']`
---> if you want all 3 features you must do `-f id lit uast2seq` -> `feature=['id', 'lit', 'uast2seq']`

Since this is also true for the languages param I added `Python`as a second language