### PR TITLE
[FIX] Repartitionner

### DIFF
--- a/apollo/__main__.py
+++ b/apollo/__main__.py
@@ -9,7 +9,8 @@ from modelforge.logs import setup_logging
 from sourced.ml import extractors
 from sourced.ml.utils import add_engine_args, add_spark_args
 from sourced.ml.cmd import ArgumentDefaultsHelpFormatterNoNone
-from sourced.ml.cmd.args import add_bow_args, add_feature_args, add_repo2_args, add_df_args
+from sourced.ml.cmd.args import add_bow_args, add_feature_args, add_repo2_args, \
+    add_df_args, add_repartitioner_arg
 from sourced.ml.transformers import Moder
 
 
@@ -117,6 +118,7 @@ def get_parser() -> argparse.ArgumentParser:
     add_feature_args(source2bags_parser)
     add_cassandra_args(source2bags_parser)
     add_df_args(source2bags_parser)
+    add_repartitioner_arg(source2bags_parser)
 
     # ------------------------------------------------------------------------
     hash_parser = subparsers.add_parser(
@@ -134,6 +136,7 @@ def get_parser() -> argparse.ArgumentParser:
     add_cassandra_args(hash_parser)
     add_spark_args(hash_parser, default_packages=[CASSANDRA_PACKAGE])
     add_feature_weight_arg(hash_parser)
+    add_repartitioner_arg(hash_parser)
 
     # ------------------------------------------------------------------------
     query_parser = subparsers.add_parser("query", help="Query for similar files.")

--- a/doc/cmd/bags.md
+++ b/doc/cmd/bags.md
@@ -12,6 +12,8 @@ This command converts input repositories to unordered weighted bags of features 
 - `--min-docfreq`: Specific minimum document frequency of each feature, defaults to 1
 - `--docfreq`: Path to the output Ordered Document Frequency model
 - `-v`/`--vocabulary-size`: to specify the maximum vocabulary size, defaults to 10 million
+- `--partitions`: to repartition data, this will specify new number of partitions 
+- `--shuffle`: to repartition data, this will allow data shuffling (vital if number of partitions increases !) 
 - [Spark and Engine arguments](https://github.com/src-d/ml/blob/master/doc/spark.md)
 - [Cassandra/Scylla arguments](db.md)
 

--- a/doc/cmd/hash.md
+++ b/doc/cmd/hash.md
@@ -10,6 +10,8 @@ This command applies the MinHashCUDA algorithm on previously written batches, st
 - `--devices`: Index of NVIDIA device to use, defaults to 0 (all available)
 - `--docfreq`: Path to the input Ordered Document Frequency model
 - `--size`: Hash size, defaults to 128
+- `--partitions`: to repartition data, this will specify new number of partitions 
+- `--shuffle`: to repartition data, this will allow data shuffling (vital if number of partitions increases !) 
 - [Cassandra/Scylla arguments](db.md)
 - [Spark arguments](https://github.com/src-d/ml/blob/master/doc/spark.md)
 


### PR DESCRIPTION
**CONTEXT**

After adding repartition args in ml we forgot to add them here, which caused a bug due to missing args in bags since they are used in `repos2bow`.

**CHANGES**

- Updated doc
- Added repartition args to bags *and* hash commands
- Added coalesce in hash before writing both hash and hashtables1/2 tables

**NB**

Not sure whether we should repartition to the same amount hash and hashtables, would like input on this as it might be best to repartition differently but with a fixed constant like we do in repos2bow.