### PR TITLE
Fix missing DzhigurdaFiles Transformer

### DIFF
--- a/apollo/bags.py
+++ b/apollo/bags.py
@@ -1,6 +1,6 @@
 from pyspark.sql.types import Row
 from sourced.ml.cmd.repos2bow import repos2bow_entry_template
-from sourced.ml.transformers import Transformer
+from sourced.ml.transformers import Transformer, DzhigurdaFiles
 
 from apollo import cassandra_utils
 


### PR DESCRIPTION
We use it, but forget to import.
Small fix after `preprocess` subcommand was moved.