### PR TITLE
[FIX] evalcc command

### DIFF
--- a/apollo/graph.py
+++ b/apollo/graph.py
@@ -14,7 +14,7 @@ from pyspark.sql.types import Row
 from scipy.sparse import csr_matrix
 from sourced.ml.utils import create_spark
 
-from apollo.cassandra_utils import get_db, patch_tables, BatchedHashResolver, Session
+from apollo.cassandra_utils import get_db, configure, BatchedHashResolver, Session
 from apollo.query import weighted_jaccard, stream_template
 
 
@@ -375,7 +375,7 @@ class CommunityEvaluator:
 def evaluate_communities(args):
     log = logging.getLogger("evalcc")
     model = CommunitiesModel().load(args.input)
-    patch_tables(args)
+    configure(args)
     spark = create_spark("evalcc-%s" % uuid4(), **args.__dict__)
     log.info("Preparing the communities' RDD")
     items = []

--- a/doc/cmd/evalcc.md
+++ b/doc/cmd/evalcc.md
@@ -8,4 +8,8 @@ This command calculates the precise similarity and fitness metrics for the given
 - `-t`/`--threshold`: Jacquard Similarity threshold (float in [0,1]) over which we consider there is similarity - to calculate number of misses
 - [Cassandra/Scylla arguments](db.md)
 - [Spark arguments](https://github.com/src-d/ml/blob/master/doc/spark.md)
- 
+
+__Note:__
+
+To run this command it is advised to set the Spark parameter `spark.default.parallelism` to a
+higher value then the default 200 partitions if you are running on large amounts the data.


### PR DESCRIPTION
Small bug related to configuring cassandra that was not ported here. I added two lines of doc after hitting on errors with Spark due to using default parallelization values -> cassandra read error due to putting too much data in too little partitions