### PR TITLE
Revert "Skipping sign-off for organization members"

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,2 +1,0 @@
-require:
-  members: false


### PR DESCRIPTION
This reverts commit 0f7d3a4903b2f2820d21a00900bf8025e3b0193c.

Source{d} members should sign commits anyway. 